### PR TITLE
Bump rq-scheduler dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Currently, when you pip install Django RQ Scheduler the following packages are a
 * django >= 1.9
 * django-model-utils >= 2.4
 * django-rq >= 0.9.3 (Django RQ requires RQ >= 0.5.5)
-* rq-scheduler >= 0.6.0
+* rq-scheduler >= 0.9.1
 * pytz >= 2015.7
 * croniter >= 0.3.24
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'django>=1.9.0',
         'django-model-utils>=4.0.0',
         'django-rq>=1.2.0',
-        'rq-scheduler==0.9.1',
+        'rq-scheduler>=0.9.1',
         'pytz>=2018.5',
         'croniter>=0.3.24',
     ],


### PR DESCRIPTION
`rq-scheduler 0.11.0` adds support for multiple schedulers which increased reliability. This repo is currently pinned to 0.9.1.