### PR TITLE
fix(DOPS-759): Add IS_SCHEDULER check to prevent worker DB connection issues

### DIFF
--- a/.github/workflows/merge-checks-complete.yml
+++ b/.github/workflows/merge-checks-complete.yml
@@ -1,0 +1,16 @@
+name: Merge Checks Complete
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+      - prod
+      - dev
+
+jobs:
+  merge-checks-complete:
+    runs-on: ubuntu-latest
+    steps:
+      - name: merge-checks-complete
+        run: echo 0

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sumit-chopra @mattjegan @delta1513 @rmartin48

--- a/scheduler/apps.py
+++ b/scheduler/apps.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import os
+
 from django.apps import AppConfig
 from django.db.models.functions import Now
 from django.utils.translation import gettext_lazy as _
@@ -10,6 +12,9 @@ class SchedulerConfig(AppConfig):
     verbose_name = _('Django RQ Scheduler')
 
     def ready(self):
+        if os.environ.get('IS_SCHEDULER') != 'True':
+            return
+
         try:
             self.reschedule_cron_jobs()
             self.reschedule_repeatable_jobs()


### PR DESCRIPTION
This PR aims to solve the issue where RQ workers hold onto stale connections whenever the database connection is dropped.

I've had a hypothesis in mind for a while and there is some evidence in [this issue](https://github.com/rq/django-rq/issues/216) that shows the following:
- When the RQ parent process is initialised, it will initialise all Django apps as usual
- During this initialisation, it's possible that a DB call is performed
- When the DB call is performed, Django manages the connection as a file descriptor (FD) as all unix systems will do
- When a workhorse (job) is spun up, this process is forked and the parent FD is given to the child
- As a result, if this connection fails in any way, it will remain stale until the process is restarted

So theoretically, if we are to remove this DB call on initialisation of Django, then we will avoid this sharing of the FD and each workhorse will be responsible for spinning up a new DB connection.

I did some debugging, and this is the only place that performs a DB call whenever the app is initialised:

```
============================================================
DATABASE CONNECTION CREATED!
Process ID: 1
Connection alias: default
Stack trace:
  File "/app/manage.py", line 21, in <module>
    execute_from_command_line(sys.argv)
  File "/app/.venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/app/.venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 416, in execute
    django.setup()
  File "/app/.venv/lib/python3.10/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/app/.venv/lib/python3.10/site-packages/django/apps/registry.py", line 124, in populate
    app_config.ready()
  File "/app/.venv/lib/python3.10/site-packages/scheduler/apps.py", line 14, in ready
    self.reschedule_cron_jobs()
  File "/app/.venv/lib/python3.10/site-packages/scheduler/apps.py", line 25, in reschedule_cron_jobs
    self.reschedule_jobs(jobs)
  File "/app/.venv/lib/python3.10/site-packages/scheduler/apps.py", line 39, in reschedule_jobs
    for job in jobs:
  File "/app/.venv/lib/python3.10/site-packages/django/db/models/query.py", line 400, in __iter__
    self._fetch_all()
  File "/app/.venv/lib/python3.10/site-packages/django/db/models/query.py", line 1886, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/app/.venv/lib/python3.10/site-packages/django/db/models/query.py", line 93, in __iter__
    results = compiler.execute_sql(
  File "/app/.venv/lib/python3.10/site-packages/django/db/models/sql/compiler.py", line 1560, in execute_sql
    cursor = self.connection.cursor()
  File "/app/.venv/lib/python3.10/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/app/.venv/lib/python3.10/site-packages/django/db/backends/base/base.py", line 329, in cursor
    return self._cursor()
  File "/app/.venv/lib/python3.10/site-packages/django/db/backends/base/base.py", line 305, in _cursor
    self.ensure_connection()
  File "/app/.venv/lib/python3.10/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/app/.venv/lib/python3.10/site-packages/django/db/backends/base/base.py", line 288, in ensure_connection
    self.connect()
  File "/app/.venv/lib/python3.10/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/app/.venv/lib/python3.10/site-packages/django/db/backends/base/base.py", line 272, in connect
    connection_created.send(sender=self.__class__, connection=self)
  File "/app/.venv/lib/python3.10/site-packages/django/dispatch/dispatcher.py", line 176, in send
    return [
  File "/app/.venv/lib/python3.10/site-packages/django/dispatch/dispatcher.py", line 177, in <listcomp>
    (receiver, receiver(signal=self, sender=sender, **named))
  File "/app/core/apps.py", line 29, in log_connection_created
    traceback.print_stack()
============================================================
```

This PR also contains some extra stuff to conform to our GH repo requirements.